### PR TITLE
update token param documentation to reference AzureAuth namespace

### DIFF
--- a/R/vault_endpoint.R
+++ b/R/vault_endpoint.R
@@ -82,7 +82,7 @@ AzureKeyVault <- R6::R6Class("AzureKeyVault", public=list(
 #' @param domain The domain of the vault; for the public Azure cloud, this is `vault.azure.net`. Also the resource for OAuth authentication.
 #' @param as_managed_identity Whether to authenticate as a managed identity. Use this if your R session is taking place inside an Azure VM or container that has a system- or user-assigned managed identity assigned to it.
 #' @param ... Further arguments that will be passed to either `get_azure_token` or [`AzureAuth::get_managed_token`], depending on whether `as_managed_identity` is TRUE.
-#' @param token An OAuth token obtained via `get_azure_token` or `get_managed_token`. If provided, this overrides the other authentication arguments.
+#' @param token An OAuth token obtained via [`AzureAuth::get_azure_token`] or [`AzureAuth::get_managed_token`]. If provided, this overrides the other authentication arguments.
 #'
 #' @details
 #' This function creates a new Key Vault client object. It includes the following component objects for working with data in the vault:

--- a/man/key_vault.Rd
+++ b/man/key_vault.Rd
@@ -25,7 +25,7 @@ key_vault(
 
 \item{as_managed_identity}{Whether to authenticate as a managed identity. Use this if your R session is taking place inside an Azure VM or container that has a system- or user-assigned managed identity assigned to it.}
 
-\item{token}{An OAuth token obtained via \code{get_azure_token} or \code{get_managed_token}. If provided, this overrides the other authentication arguments.}
+\item{token}{An OAuth token obtained via \code{\link[AzureAuth:get_azure_token]{AzureAuth::get_azure_token}} or \code{\link[AzureAuth:get_azure_token]{AzureAuth::get_managed_token}}. If provided, this overrides the other authentication arguments.}
 }
 \description{
 Azure Key Vault client


### PR DESCRIPTION
This pull request modifies the `token` argument for `key_vault()` to explicitly inform the user that the referenced functions `get_azure_token()` and `get_managed_token()` come from the `AzureAuth` namespace. 

Per https://github.com/Azure/AzureKeyVault/issues/10